### PR TITLE
Remove option { all = false } in iter_matches() as it was removed in nvim-0.12

### DIFF
--- a/lua/outline/providers/treesitter/aerial/init.lua
+++ b/lua/outline/providers/treesitter/aerial/init.lua
@@ -40,7 +40,7 @@ M.fetch_symbols_sync = function(bufnr)
   local stack = {}
   local ext = extensions[lang]
   for _, matches, metadata in
-    query:iter_matches(syntax_tree:root(), bufnr, nil, nil, { all = false })
+    query:iter_matches(syntax_tree:root(), bufnr, nil, nil)
   do
     ---@note mimic nvim-treesitter's query.iter_group_results return values:
     --       {
@@ -57,7 +57,9 @@ M.fetch_symbols_sync = function(bufnr)
     --       }
     --- Matches can overlap. The last match wins.
     local match = vim.tbl_extend("force", {}, metadata)
-    for id, node in pairs(matches) do
+    for id, nodes in pairs(matches) do
+      -- preserve the old iter_matches({all = false}) behavior
+      local node = nodes[#nodes]
       -- iter_group_results prefers `#set!` metadata, keeping the behaviour
       match = vim.tbl_extend("keep", match, {
         [query.captures[id]] = {


### PR DESCRIPTION
Note that the code was merely synced with the upstream aerial code (see at https://github.com/stevearc/aerial.nvim/blob/645d108a5242ec7b378cbe643eb6d04d4223f034/lua/aerial/backends/treesitter/init.lua#L49).

The old code causes errors in, for example, markdown files with embedded code blocks of other languages.